### PR TITLE
sdcardfs: limit stacking depth

### DIFF
--- a/fs/sdcardfs/main.c
+++ b/fs/sdcardfs/main.c
@@ -281,6 +281,13 @@ static int sdcardfs_read_super(struct vfsmount *mnt, struct super_block *sb,
 	atomic_inc(&lower_sb->s_active);
 	sdcardfs_set_lower_super(sb, lower_sb);
 
+	sb->s_stack_depth = lower_sb->s_stack_depth + 1;
+	if (sb->s_stack_depth > FILESYSTEM_MAX_STACK_DEPTH) {
+		pr_err("sdcardfs: maximum fs stacking depth exceeded\n");
+		err = -EINVAL;
+		goto out_sput;
+	}
+
 	/* inherit maxbytes from lower file system */
 	sb->s_maxbytes = lower_sb->s_maxbytes;
 


### PR DESCRIPTION
Limit filesystem stacking to prevent stack overflow.

Bug: 32761463
Change-Id: I8b1462b9c0d6c7f00cf110724ffb17e7f307c51e
Signed-off-by: Andrew Chant <achant@google.com>