### PR TITLE
qpnp-smbcharger: Publish charger voltage to the usb psy

### DIFF
--- a/drivers/power/qpnp-smbcharger.c
+++ b/drivers/power/qpnp-smbcharger.c
@@ -2289,6 +2289,8 @@ static void smbchg_parallel_usb_enable(struct smbchg_chip *chip,
 			"Couldn't set Vflt on parallel psy rc: %d\n", rc);
 		return;
 	}
+	power_supply_set_voltage_limit(chip->usb_psy,
+			(chip->vfloat_mv + 50) * 1000);
 	/* Set USB ICL */
 	target_icl_ma = get_effective_result_locked(chip->usb_icl_votable);
 	new_parallel_cl_ma = total_current_ma
@@ -3232,8 +3234,11 @@ static int smbchg_float_voltage_set(struct smbchg_chip *chip, int vfloat_mv)
 
 	if (rc)
 		dev_err(chip->dev, "Couldn't set float voltage rc = %d\n", rc);
-	else
+	else {
 		chip->vfloat_mv = vfloat_mv;
+		power_supply_set_voltage_limit(chip->usb_psy,
+				chip->vfloat_mv * 1000);
+	}
 
 	return rc;
 }


### PR DESCRIPTION
Since N, the Keyguard uses watt data rather than amperage alone. It
needs both voltage and amperage information for the power supply
subsystem to do so.

This brings back the "Charging slowly", "Charging" and "Charging
rapidly" texts on the lock screen.

Change-Id: Iac37d8b69d2acc048e8c132b2c26c2bed3676d75